### PR TITLE
suggestionにも対応するべきかどうか

### DIFF
--- a/main.tsx
+++ b/main.tsx
@@ -62,11 +62,23 @@ app.get("/", (c) => {
             placeholder="https://example.org/search?q=%s"
             required
           />
-          <p>検索キーワードに %s を入れて検索したURLを貼り付ける</p>
+        </label>
+        <p>検索キーワードに %s を入れて検索したURLを貼り付ける</p>
+        <label>
+          Name (Optional)
+          <input type="text" name="name" placeholder="Example検索" />
         </label>
         <label>
-          Name
-          <input type="text" name="name" placeholder="Example検索" />
+          <input type="checkbox" name="googlesuggest" />
+          Google Suggestionsを使用する
+        </label>
+        <label>
+          Suggestions URL (Optional)
+          <input
+            type="text"
+            name="suggest"
+            placeholder="https://example.org/suggestions?q=%s"
+          />
         </label>
         <button type="submit">追加用ページ生成</button>
       </form>

--- a/openSearchDescription.ts
+++ b/openSearchDescription.ts
@@ -6,6 +6,7 @@ interface osdxParams {
   shortName: string;
   description: string;
   searchURL: string;
+  suggestionURL?: string;
   imageURL: string;
 }
 export function getParams(
@@ -25,14 +26,26 @@ export function getParams(
   const shortName = query.name || hostname;
   const imageURL = query.icon ||
     `https://www.google.com/s2/favicons?domain=${hostname}`;
-  return { ok: true, shortName, description, searchURL, imageURL };
+  const suggestionURL = query.googlesuggest
+    ? "https://www.google.com/complete/search?client=chrome&q=" +
+      osdxSearchTerms
+    : query.suggest?.replaceAll(searchTerms, osdxSearchTerms);
+  return {
+    ok: true,
+    ...{ shortName, description, searchURL, imageURL },
+    ...(suggestionURL?.includes(osdxSearchTerms) ? { suggestionURL } : {}),
+  };
 }
 export function openSearchDescription(params: osdxParams) {
+  const suggest = params.suggestionURL
+    ? html`
+  <Url type="application/x-suggestions+json" template="${params.suggestionURL}"/>`
+    : "";
   return (html`<?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
   <ShortName>${params.shortName}</ShortName>
   <Description>${params.description}</Description>
-  <Url type="text/html" method="get" template="${params.searchURL}"/>
+  <Url type="text/html" method="get" template="${params.searchURL}"/>${suggest}
   <Image width="16" height="16">${params.imageURL}</Image>
   <InputEncoding>UTF-8</InputEncoding>
 </OpenSearchDescription>


### PR DESCRIPTION
解決策 #1
対応しているサイトのSuggestion JSON URLを入力する`input[type="url"]`と対応していないサイトにGoogle Suggestionsで代替する`input[type="checkbox"]`を追加し、対応した

- フォームに`input[type="url"][name="suggest"]`を追加
- フォームに`input[type="checkbox"][name="googlesuggest"]`を追加
- getParamsに上2つからsuggestionURLを追加
- openSearchDescriptionに`<Url type="application/x-suggestions+json">`を追加